### PR TITLE
fix: netlify index html paths

### DIFF
--- a/@kindspells/astro-shield/package.json
+++ b/@kindspells/astro-shield/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kindspells/astro-shield",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "Astro integration to enhance your website's security with SubResource Integrity hashes, Content-Security-Policy headers, and other techniques.",
 	"private": false,
 	"type": "module",

--- a/@kindspells/astro-shield/src/netlify.mts
+++ b/@kindspells/astro-shield/src/netlify.mts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import type {
 	CSPDirectives,
 	HashesCollection,
+	PerPageHashes,
 	SecurityHeadersOptions,
 } from './types.mts'
 import { serialiseCspDirectives, setSrcDirective } from './headers.mts'
@@ -251,9 +252,16 @@ export const buildNetlifyHeadersConfig = (
 		entries: [],
 	}
 
-	for (const [page, hashes] of Array.from(
-		resourceHashes.perPageSriHashes,
-	).sort()) {
+	const pagesToIterate: [string, PerPageHashes][] = []
+	for (const [page, hashes] of resourceHashes.perPageSriHashes) {
+		if (page === 'index.html' || page.endsWith('/index.html')) {
+			pagesToIterate.push([page.slice(0, -10), hashes])
+		}
+		pagesToIterate.push([page, hashes])
+	}
+	pagesToIterate.sort()
+
+	for (const [page, hashes] of pagesToIterate) {
 		const pathEntries: (HeaderEntry | CommentEntry)[] = []
 
 		if (securityHeadersOptions.contentSecurityPolicy !== undefined) {

--- a/@kindspells/astro-shield/src/tests/netlify.test.mts
+++ b/@kindspells/astro-shield/src/tests/netlify.test.mts
@@ -235,6 +235,77 @@ describe('buildNetlifyHeadersConfig', () => {
 			],
 		} satisfies NetlifyHeadersRawConfig)
 	})
+
+	it('creates a "double entry" for "index.html" files', () => {
+		const config = buildNetlifyHeadersConfig(
+			{ contentSecurityPolicy: {} },
+			{
+				perPageSriHashes: new Map([
+					[
+						'index.html',
+						{
+							scripts: new Set([
+								'sha256-071spvYLMvnwaR0H7M2dfK0enB0cGtydTbgJkdoWq7c=',
+							]),
+							styles: new Set(),
+						},
+					],
+					[
+						'es/index.html',
+						{
+							scripts: new Set([
+								'sha256-071spvYLMvnwaR0H7M2dfK0enB0cGtydTbgJkdoWq7c=',
+							]),
+							styles: new Set(),
+						},
+					],
+					[
+						'fakeindex.html',
+						{
+							scripts: new Set([
+								'sha256-071spvYLMvnwaR0H7M2dfK0enB0cGtydTbgJkdoWq7c=',
+							]),
+							styles: new Set(),
+						},
+					],
+				]),
+			},
+		)
+
+		const testEntries = [
+			{
+				headerName: 'content-security-policy',
+				value:
+					"script-src 'self' 'sha256-071spvYLMvnwaR0H7M2dfK0enB0cGtydTbgJkdoWq7c='; style-src 'none'",
+			},
+		]
+
+		expect(config).toEqual({
+			indentWith: '\t',
+			entries: [
+				{
+					path: '/',
+					entries: testEntries,
+				},
+				{
+					path: '/es/',
+					entries: testEntries,
+				},
+				{
+					path: '/es/index.html',
+					entries: testEntries,
+				},
+				{
+					path: '/fakeindex.html',
+					entries: testEntries,
+				},
+				{
+					path: '/index.html',
+					entries: testEntries,
+				},
+			],
+		} satisfies NetlifyHeadersRawConfig)
+	})
 })
 
 describe('mergeNetlifyHeadersConfig', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1514,6 +1514,9 @@ packages:
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
+  hast-util-minify-whitespace@1.0.0:
+    resolution: {integrity: sha512-gD1m4YJSIk62ij32TlhFNqsC3dOQvpA4QAhyZOZFAT4u8LfEfB6N+F0V9oXQGBWXoqrs0h9wQRKa8RCeo8j61g==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
@@ -2203,8 +2206,8 @@ packages:
   rehype-format@5.0.0:
     resolution: {integrity: sha512-kM4II8krCHmUhxrlvzFSptvaWh280Fr7UGNJU5DCMuvmAwGCNmGfi9CvFAQK6JDjsNoRMWQStglK3zKJH685Wg==}
 
-  rehype-minify-whitespace@6.0.0:
-    resolution: {integrity: sha512-i9It4YHR0Sf3GsnlR5jFUKXRr9oayvEk9GKQUkwZv6hs70OH9q3OCZrq9PpLvIGKt3W+JxBOxCidNVpH/6rWdA==}
+  rehype-minify-whitespace@6.0.1:
+    resolution: {integrity: sha512-3oJZ3O8ukn6cNJ8elg8dU/tMCH4CDk7elE9x5G+dKL1qQYXeVnsDkSz17sAiUKIoDOXUUkOyC/VMNGEHbPmCew==}
 
   rehype-parse@9.0.0:
     resolution: {integrity: sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==}
@@ -4374,6 +4377,14 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-minify-whitespace@1.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-is-element: 3.0.0
+      hast-util-whitespace: 3.0.0
+      unist-util-is: 6.0.0
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -5426,16 +5437,13 @@ snapshots:
       hast-util-phrasing: 3.0.1
       hast-util-whitespace: 3.0.0
       html-whitespace-sensitive-tag-names: 3.0.0
-      rehype-minify-whitespace: 6.0.0
+      rehype-minify-whitespace: 6.0.1
       unist-util-visit-parents: 6.0.1
 
-  rehype-minify-whitespace@6.0.0:
+  rehype-minify-whitespace@6.0.1:
     dependencies:
       '@types/hast': 3.0.4
-      hast-util-embedded: 3.0.0
-      hast-util-is-element: 3.0.0
-      hast-util-whitespace: 3.0.0
-      unist-util-is: 6.0.0
+      hast-util-minify-whitespace: 1.0.0
 
   rehype-parse@9.0.0:
     dependencies:


### PR DESCRIPTION
When dealing with `index.html` files, the generation of CSP headers for static content on Netlify was "forgetting" to set those same headers for the corresponding `/` paths; now this is fixed.